### PR TITLE
Revert "readmeにdockerコマンド追加"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,1 @@
 # Readmeファイルの作成
-
-
-開発環境では以下のdockerコードを使用してローカルで実行できます。
-
-```bash
-docker-compose -f docker-compose.yml build
-```
-
-
-本番環境では以下のdockerコードを使用してローカルで実行できます。
-
-```bash
-docker-compose -f docker-compose.yml -f docker-compose.prod.yml build
-```


### PR DESCRIPTION
Reverts takumi123/docker-slackbot#1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed Docker usage instructions from the README, resulting in a more concise document but reducing guidance for users setting up their environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->